### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/hosts/frameworkstation/cfg/users/anegrel/desktop/wm/sway/default.nix
+++ b/hosts/frameworkstation/cfg/users/anegrel/desktop/wm/sway/default.nix
@@ -64,7 +64,7 @@ let
 in
 {
   environment.systemPackages = with pkgs; [
-    # https://nixos.wiki/wiki/Sway#Using_NixOS
+    # https://wiki.nixos.org/wiki/Sway#Using_NixOS
     configure-gtk
     dbus-sway-environment
     polkit-gnome-authentication-agent


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️